### PR TITLE
Don't skip checkbox value if not set, treat as false.

### DIFF
--- a/carnie-gigs.php
+++ b/carnie-gigs.php
@@ -4,7 +4,7 @@
  * Plugin Name: Carnie Gigs
  * Plugin URI: https://github.com/OpenAirOrchestra/carnie-gigs
  * Description: A gig calendar plugin for The Carnival Band 
- * Version: 1.3.2
+ * Version: 1.3.3
  * Author: Open Air Orchestra Webmonkey
  * Author URI: mailto://oaowebmonkey@gmail.com
  * License: GPL2

--- a/controllers/meta_box_admin.php
+++ b/controllers/meta_box_admin.php
@@ -13,9 +13,11 @@ class carnieGigsMetaFormController {
 			$old = get_post_meta($post_id, $field['id'], true);
 
 			$key = $field['id'];
-			if (!isset($data[$key])) {
+
+			if (!isset($data[$key]) && $field['type'] != 'checkbox') {
 				continue;
 			}
+
 			$new = $data[$key];
 			if (! $new) {
 				$key = str_replace($metadata_prefix, '', $key);

--- a/readme.txt
+++ b/readme.txt
@@ -143,3 +143,6 @@ Don't deisplay 00:00:00 times in shortcode gig table display.
 
 = 1.3.2 =
 Add Accessibility section
+
+= 1.3.3 = 
+Fix checkbox bug introduced in 1.3.2 

--- a/version.php
+++ b/version.php
@@ -1,6 +1,6 @@
 <?php
 
 define("CARNIE_GIGS_DB_VERSION", 4);
-define("CARNIE_GIGS_PLUGIN_VERSION", '1.3.2');
+define("CARNIE_GIGS_PLUGIN_VERSION", '1.3.3');
 
 ?>


### PR DESCRIPTION
Don't skip checkbox value if not set, treat as false.
Skipping unset values introduced a bug where checkboxes couldn't be unset.   This is because we don't get "off" for the value, instead the checkbox value is unset.

This fixes the bug introduced in 1.3.2